### PR TITLE
fix: void reader and propagate errors to caller

### DIFF
--- a/rcon.ts
+++ b/rcon.ts
@@ -1,4 +1,5 @@
 import { concat, equals } from './deps.ts';
+import { iterateReader } from 'https://deno.land/std@0.117.0/streams/conversion.ts';
 
 const FrameBuffer = new Uint8Array([0, 1, 0, 0]);
 
@@ -41,7 +42,7 @@ export class Rcon {
   constructor(
     private host = 'localhost',
     private port = 27015,
-    private password = '',
+    private password = ''
   ) {}
 
   sendCmd(cmd: string) {
@@ -68,7 +69,7 @@ export class Rcon {
   private async read() {
     const conn = this.conn!;
     try {
-      for await (const chunk of Deno.iter(conn)) {
+      for await (const chunk of iterateReader(conn)) {
         this.readChunk(chunk);
       }
     } finally {

--- a/rcon.ts
+++ b/rcon.ts
@@ -55,7 +55,7 @@ export class Rcon {
         hostname: this.host,
         port: this.port,
       });
-      this.read().catch(() => {});
+      void this.read();
       await this.sendData(
         new Uint8Array([0, 0, 0, 0]),
         this.password,

--- a/rcon.ts
+++ b/rcon.ts
@@ -52,11 +52,14 @@ export class Rcon {
   private async connect() {
     if (!this.conn) {
       this.authed = new ResolvablePromise();
+
       this.conn = await Deno.connect({
         hostname: this.host,
         port: this.port,
       });
+
       void this.read();
+
       await this.sendData(
         new Uint8Array([0, 0, 0, 0]),
         this.password,
@@ -108,9 +111,6 @@ export class Rcon {
         const id = dataView.getInt32(4, true);
         const type = dataView.getInt32(8, true);
         const payload = data.slice(12, 12 + len - 10);
-        /*console.log(
-          `payload size: ${payload.length}, id: ${id}, type: ${type}`
-        );*/
         if (id !== -1) {
           if (type === PacketType.RESPONSE_AUTH && id === 0) {
             this.authed?.resolve();
@@ -139,7 +139,6 @@ export class Rcon {
         // Keep the data of the chunk if it doesn't represent a full packet
         this.outstandingData = new Uint8Array(data.length);
         this.outstandingData.set(data, 0);
-        // console.log('outstanding data: ', this.outstandingData.length);
         break;
       }
     }
@@ -162,7 +161,6 @@ export class Rcon {
   }
 
   private async sendData(id: Uint8Array, data: string, packetType: number) {
-    // console.log('sending', id, data, packetType);
     const dataBuffer = new TextEncoder().encode(data);
     const dataLength = dataBuffer.length;
 


### PR DESCRIPTION
A few things:
1) Void the reading of the body (linter happiness)
2) Remove deprecated Deno api in favor for their alternative (std library streams module)
3) Remove commented debugging logs

Confirmed this package works with these changes on deno.deploy, but fails without them. We also don't catch errors from reading the body, instead they should be directed to the caller to get more information.